### PR TITLE
fix: forward input ref and clean lint

### DIFF
--- a/app/components/game/stats-card.tsx
+++ b/app/components/game/stats-card.tsx
@@ -3,7 +3,7 @@ import { Separator } from "../ui/separator";
 import { Progress } from "../ui/progress";
 // Button not used directly after AddIconButton extraction
 import { PlusIcon } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { AddDrawer } from "./add-drawer";
 import { Input } from "../ui/input";
 import { InlineEditableBadge } from "./inline-editable-badge";
@@ -12,6 +12,10 @@ import { Stat } from "@/types/stats.type";
 import { AddIconButton } from "./add-icon-button";
 import { Label } from "../ui/label";
 
+function ProgressBar({ stat }: { stat: Stat }) {
+  const progress = (stat.value / stat.range[1]) * 100;
+  return <Progress value={progress} max={100} className="h-2 mt-1" />;
+}
 export function StatsCard() {
   const { stats, addToStats, updateStat, removeFromStats } = useGameStore();
   const [open, setOpen] = useState(false);
@@ -22,12 +26,6 @@ export function StatsCard() {
     stats.some((s) => s.name.toLowerCase() === candidate.trim().toLowerCase());
   const canSubmit = name.trim() && !nameExists(name);
 
-  const ProgressBar = useMemo(() => {
-    return (stat: Stat) => {
-      const progress = (stat.value / stat.range[1]) * 100;
-      return <Progress value={progress} max={100} className="h-2 mt-1" />;
-    };
-  }, [stats]);
   return (
     <div ref={containerRef} className="relative overflow-hidden">
       <div className="py-1 flex flex-col gap-1 mt-1">
@@ -85,7 +83,7 @@ export function StatsCard() {
                     />
                   </div>
                 </div>
-                {ProgressBar(stat)}
+                <ProgressBar stat={stat} />
               </div>
             ))}
           </div>

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -2,20 +2,25 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
-  return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        data-slot="input"
+        className={cn(
+          "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+Input.displayName = "Input";
 
 export { Input };

--- a/app/pages/demo/demo.tsx
+++ b/app/pages/demo/demo.tsx
@@ -33,12 +33,11 @@ import {
 import { nanoid } from "nanoid";
 import { InlineEditableContent, LogEntryBubble } from "@/components/game";
 import { LogEntryMode, LogEntryRole } from "@/types/log.type";
-    interface Action {
+interface Action {
   type: LogEntryMode;
   isRolling: boolean;
 }
 function getPlaceholder(action: Action) {
-  
   let placeholder = "";
   switch (action.type) {
     case LogEntryMode.DO:
@@ -138,7 +137,7 @@ export default function Demo() {
 
     let storyContent = "";
 
-    send({text: message, mode}, model, {
+    send({ text: message, mode }, model, {
       onStoryStream: (storyChunk) => {
         storyContent += storyChunk;
         updateLogEntry(gmResponseId, {
@@ -200,15 +199,10 @@ export default function Demo() {
   const handleSubmit = useCallback(async () => {
     if (!input.trim() || !model) return;
 
-    let finalMessage: string;
-    let logMode: LogEntryMode;
-
-      const playerInput = action.isRolling
-        ? input + ` [Roll: ${Math.floor(Math.random() * 100) + 1}/100]`
-        : input;
-      finalMessage = playerInput;
-      logMode = action.type;
-
+    const finalMessage = action.isRolling
+      ? input + ` [Roll: ${Math.floor(Math.random() * 100) + 1}/100]`
+      : input;
+    const logMode: LogEntryMode = action.type;
 
     addLog({
       id: nanoid(),
@@ -232,13 +226,16 @@ export default function Demo() {
       secondLastEntry?.role === LogEntryRole.PLAYER
     ) {
       removeLastLogEntry();
-      executeLlmSend(secondLastEntry.text, secondLastEntry.mode ?? LogEntryMode.STORY);
+      executeLlmSend(
+        secondLastEntry.text,
+        secondLastEntry.mode ?? LogEntryMode.STORY,
+      );
     } else {
       console.warn("Cannot retry, log state is not as expected.");
     }
   };
 
-    // Shared content component for both modes
+  // Shared content component for both modes
   const renderMainContent = () => (
     <>
       <ScrollArea
@@ -285,9 +282,7 @@ export default function Demo() {
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="text-xs">
-                      <p>
-                        Failed to parse actions returned with this message.
-                      </p>
+                      <p>Failed to parse actions returned with this message.</p>
                     </TooltipContent>
                   </Tooltip>
                 )}
@@ -366,11 +361,7 @@ export default function Demo() {
               className="absolute inset-x-0 bottom-0 resize-none rounded-xs !bg-accent"
             />
           </div>
-          <Button
-            type="submit"
-            onClick={handleSubmit}
-            className="rounded-xs"
-          >
+          <Button type="submit" onClick={handleSubmit} className="rounded-xs">
             {loading ? (
               <SquareIcon className="w-4 h-4 animate-pulse" />
             ) : (
@@ -378,7 +369,6 @@ export default function Demo() {
             )}
           </Button>
           <LogControl handleRetry={handleRetry} loading={loading} />
-
         </div>
       </div>
       <div className="pointer-events-none absolute inset-0">


### PR DESCRIPTION
## Summary
- forward refs for Input component to allow focusing and parent ref access
- fix StatsCard progress bar definition
- clean up handleSubmit variable declarations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run format` *(fails: Code style issues found in 11 files. Run Prettier with --write to fix.)*

------
https://chatgpt.com/codex/tasks/task_e_68a88f50c3b4832f8701abc45eab68b5